### PR TITLE
Exclude examples for composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+example/ export-ignore


### PR DESCRIPTION
When the package is fetched via composer, there is no need for the examples to be served as well.